### PR TITLE
fix: bug fix on the string align

### DIFF
--- a/src/align.rs
+++ b/src/align.rs
@@ -100,7 +100,7 @@ pub fn align_text_horizontal(
                     if let Some(st) = style {
                         sp = format!("{}{}", st, sp);
                     }
-                    line = format!("{}{}", line, sp);
+                    line = format!("{}{}", sp, line);
                 }
                 _ => {
                     // Default case is left orientation.

--- a/src/style.rs
+++ b/src/style.rs
@@ -109,7 +109,7 @@ impl Style {
     }
 
     pub fn to_string(self) -> String {
-        self.render(self.value.to_string())
+        self.render(String::from(""))
     }
 
     pub fn get_as_bool(&self, prop: Props, default_val: bool) -> bool {


### PR DESCRIPTION
There was a bug on the align left and right. Both are being aligned to the same side irrespective of what the user chose. This is to fix that issue.

The solution is to correct the order in which spaces and lines are ordered in the rendering.

Also along with the ticket resolving is the bug on the rendering part.